### PR TITLE
Add dep to CMake, fix old link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,8 @@ TARGET_LINK_LIBRARIES(vcash
         ${VCASH_SRC_PATH}/deps/db/lib/libdb_cxx.a
 
         ${WXVCASHGUI_SRC_PATH}/deps/libqrencode/libqrencode.a
-
+        
+        Xxf86vm
         wx_gtk3u_richtext-3.1
         wx_gtk3u_adv-3.1
         wx_baseu_xml-3.1

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In order to build wxVcashGUI, you will need to build firstly vcash.
 
 You can build vcash by using the script at:
 
-https://github.com/xCoreDev/vcash-scripts
+https://github.com/openvcash/vcash-scripts
 
 The resulting build will be located at ~/vcash/.
 


### PR DESCRIPTION
According to wallisonalves (on Slack) and [an old link](https://bitcointalk.org/index.php?topic=725.0), wxVcashGUI won't build without this. I cannot test myself (not on a Debian-based Linux), but it seemed to [work for wallisonalves](https://vcash.slack.com/archives/C3ADWAF24/p1496591959052437).

Also a minor link fix to the new (openvcash) github, instead of the old xCoreDev link.

